### PR TITLE
Add Velt to Websockets > Hosted

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@
 - [Pubnub](https://www.pubnub.com) - APIs for developers building secure realtime Mobile, Web, and IoT Apps.
 - [Pusher](https://pusher.com) - Pusher is a hosted API for realtime bi-directional functionality via WebSockets.
 - [Realtime framework](https://framework.realtime.co/messaging/) - Realtime Messaging is a cloud based message broker.
+- [Velt](https://velt.dev) - Realtime collaboration platform providing comments, presence, live cursors and CRDT editing.
 
 
 ### Subsection


### PR DESCRIPTION
Adds **Velt** to Websockets > Hosted, alongside other hosted realtime platforms (Ably, Pusher, PubNub).

Velt is a hosted realtime collaboration platform: comments, presence, live cursors, huddles and CRDT (Yjs) real-time editing.

- Site: https://velt.dev
- Docs: https://velt.dev/docs